### PR TITLE
HW-56155 error message update and small bugfix

### DIFF
--- a/transferui/src/main/java/com/hyperwallet/android/ui/transfer/view/ListTransferDestinationFragment.java
+++ b/transferui/src/main/java/com/hyperwallet/android/ui/transfer/view/ListTransferDestinationFragment.java
@@ -240,7 +240,6 @@ public class ListTransferDestinationFragment extends DialogFragment {
         TransferDestinationViewHolder(@NonNull final View itemView,
                 @NonNull final ListTransferDestinationViewModel viewModel) {
             super(itemView);
-            itemView.setOnClickListener(this);
 
             mIcon = itemView.findViewById(R.id.icon);
             mTitle = itemView.findViewById(R.id.title);
@@ -271,6 +270,7 @@ public class ListTransferDestinationFragment extends DialogFragment {
             } else {
                 mSelectedIcon.setVisibility(View.GONE);
             }
+            itemView.setOnClickListener(this);
         }
 
         void recycle() {

--- a/transferui/src/main/java/com/hyperwallet/android/ui/transfer/viewmodel/CreateTransferViewModel.java
+++ b/transferui/src/main/java/com/hyperwallet/android/ui/transfer/viewmodel/CreateTransferViewModel.java
@@ -188,7 +188,8 @@ public class CreateTransferViewModel extends ViewModel {
     }
 
     public void notifyModuleUnavailable() {
-        HyperwalletError error = new HyperwalletError(R.string.module_unavailable_error, ERROR_SDK_MODULE_UNAVAILABLE);
+        HyperwalletError error = new HyperwalletError(R.string.module_transfermethodui_unavailable_error,
+                ERROR_SDK_MODULE_UNAVAILABLE);
         HyperwalletErrors errors = new HyperwalletErrors(Arrays.asList(error));
         mModuleUnavailableError.postValue(new Event<>(errors));
     }

--- a/transferui/src/main/res/values/strings.xml
+++ b/transferui/src/main/res/values/strings.xml
@@ -24,9 +24,8 @@
     <string name="amount_currency_format">%s %s</string>
     <string name="exchange_rate_format">1 %s = %s %s</string>
 
-    <string name="module_unavailable_error">SDK module is unavailable. Please ensure, module is
-        installed.
-    </string>
+    <string name="module_transfermethodui_unavailable_error">Functionality to add an account
+        has not been included in this application.</string>
     <string name="validation_amount_required">Amount is required.</string>
     <string name="validation_destination_required">Destination account is required.</string>
 


### PR DESCRIPTION
@bolynykhw @peter-joseph @skoong - This pull request contains the code changes that update the error message the app displays when the tranfermethodui module is not included in the integrators app. It also contains a small bug fix in the selection of the destination accounts when user decides to transfer to a different transfer method. The issue happens because we attach the click listener in the view holder constructors instead of doing it when the view holder is bound the the recycler view