### PR TITLE
HW-59339 Transfer All Funds Toggle Flickers after Creating a Transfer - fixed

### DIFF
--- a/transferui/src/main/java/com/hyperwallet/android/ui/transfer/view/CreateTransferFragment.java
+++ b/transferui/src/main/java/com/hyperwallet/android/ui/transfer/view/CreateTransferFragment.java
@@ -416,7 +416,7 @@ public class CreateTransferFragment extends Fragment {
         mTransferCurrency.setTextColor(getResources().getColor(R.color.colorButtonTextDisabled));
         mTransferAmount.setEnabled(false);
         mTransferNotes.setEnabled(false);
-        mTransferAllSwitch.setEnabled(false);
+        mTransferAllSwitch.setClickable(false);
         mTransferDestination.setEnabled(false);
         mAddTransferDestination.setEnabled(false);
     }
@@ -425,7 +425,7 @@ public class CreateTransferFragment extends Fragment {
         mTransferCurrency.setTextColor(getResources().getColor(R.color.colorSecondaryDark));
         mTransferAmount.setEnabled(true);
         mTransferNotes.setEnabled(true);
-        mTransferAllSwitch.setEnabled(true);
+        mTransferAllSwitch.setClickable(true);
         mTransferDestination.setEnabled(true);
         mAddTransferDestination.setEnabled(true);
     }

--- a/transferui/src/main/res/layout/fragment_create_transfer.xml
+++ b/transferui/src/main/res/layout/fragment_create_transfer.xml
@@ -176,7 +176,7 @@
                     android:theme="@style/Widget.Hyperwallet.Switch"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:enabled="false"
+                    android:clickable="false"
                     android:layout_marginTop="@dimen/grid_margin_top"
                     android:layout_marginEnd="@dimen/widget_default_margin"
                     android:layout_marginBottom="@dimen/grid_margin_bottom"


### PR DESCRIPTION
I believe, Those enable and disable actions are used to restrict UI interaction of component(Switch) when some(backend) process ongoing. We can also restrict UI interaction by using _setClickable(false)_ instead of using _setEnabled(false)_ as per android documentation without UI changes. So it can avoid the Toggle flicker. I checked manually. Let me know if you want any corrections or alternative methods.

