### PR TITLE
DTSERWONE-821 - Handle HTTP 401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+[1.0.0-beta13](https://github.com/hyperwallet/hyperwallet-android-ui-sdk/releases/tag/1.0.0-beta13)
+-------------------
+* Handle HTTP 401
 
 [1.0.0-beta12](https://github.com/hyperwallet/hyperwallet-android-ui-sdk/releases/tag/1.0.0-beta12)
 -------------------

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ allprojects {
 
     }
 
-    project.version = "1.0.0-beta12"
+    project.version = "1.0.0-beta13"
 
 }
 
@@ -38,7 +38,7 @@ subprojects {
         targetVersion = 30
         codeVersion = 1
 
-        hyperwalletCoreVersion = '1.0.0-beta10'
+        hyperwalletCoreVersion = '1.0.0-beta12'
         hyperwalletInsightVersion = '1.0.0-beta02'
         //
         androidMaterialVersion = '1.0.0'

--- a/transfermethodui/src/androidTest/java/com/hyperwallet/android/ui/transfermethod/ListTransferMethodTest.java
+++ b/transfermethodui/src/androidTest/java/com/hyperwallet/android/ui/transfermethod/ListTransferMethodTest.java
@@ -2,8 +2,10 @@ package com.hyperwallet.android.ui.transfermethod;
 
 import static androidx.test.espresso.Espresso.onView;
 import static androidx.test.espresso.action.ViewActions.click;
+import static androidx.test.espresso.action.ViewActions.replaceText;
 import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
 import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.RootMatchers.isDialog;
 import static androidx.test.espresso.matcher.ViewMatchers.hasDescendant;
 import static androidx.test.espresso.matcher.ViewMatchers.hasSibling;
 import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
@@ -17,10 +19,12 @@ import static org.hamcrest.Matchers.is;
 
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.net.HttpURLConnection.HTTP_OK;
+import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import static com.hyperwallet.android.model.StatusTransition.StatusDefinition.DE_ACTIVATED;
 import static com.hyperwallet.android.ui.testutils.util.EspressoUtils.atPosition;
+import static com.hyperwallet.android.ui.testutils.util.EspressoUtils.nestedScrollTo;
 import static com.hyperwallet.android.ui.testutils.util.EspressoUtils.withDrawable;
 
 import android.content.BroadcastReceiver;
@@ -196,6 +200,20 @@ public class ListTransferMethodTest {
     }
 
     @Test
+    public void testListTransferMethod_displaysErrorOnUnauthorizedOnGraphQLRequest() {
+        mMockWebServer.mockResponse().withHttpResponseCode(HTTP_UNAUTHORIZED).withBody(sResourceManager
+                .getResourceContent("error_jwt_token_revoked.json")).mock();
+
+        // run test
+        mActivityTestRule.launchActivity(null);
+
+        // assert
+        onView(withText(R.string.authentication_error_header))
+                .inRoot(isDialog())
+                .check(matches(isDisplayed()));
+    }
+
+    @Test
     public void testListTransferMethod_userHasNoTransferMethods() {
         mMockWebServer.mockResponse().withHttpResponseCode(HTTP_NO_CONTENT).withBody("").mock();
 
@@ -212,6 +230,7 @@ public class ListTransferMethodTest {
         onView(withText(R.string.emptyStateAddTransferMethod)).check(matches(isDisplayed()));
 
     }
+
 
     @Test
     public void testListTransferMethod_removeBankAccount() throws InterruptedException {

--- a/transfermethodui/src/test/resources/error_jwt_token_revoked.json
+++ b/transfermethodui/src/test/resources/error_jwt_token_revoked.json
@@ -1,0 +1,8 @@
+{
+  "errors":[
+    {
+      "message":"JWT expired",
+      "code":"JWT_EXPIRED"
+    }
+  ]
+}


### PR DESCRIPTION
# Summary
Update the core SDK to handle HTTP 401

## Changes
- Bump core SDK Version to handle HTTP 401
- Introduce UI Test to handle 401 on GraphQL and Rest  requests

## Required
- [x] Required merge https://github.com/hyperwallet/hyperwallet-android-sdk/pull/137
- [ ] Deploy Android Core SDK  v `1.0.0-beta12`

## UI Test

### GraphQL
https://user-images.githubusercontent.com/107439697/187563968-baa55ace-6d84-49e7-8c30-b8dec7f7d153.mp4

### Rest 
https://user-images.githubusercontent.com/107439697/187563984-06b18e90-9c6b-4238-b386-19a3c39d0f5d.mp4

