### PR TITLE
DTONBWTWO-921 - Support android 12 requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 =========
+[1.0.0-beta14](https://github.com/hyperwallet/hyperwallet-android-ui-sdk/releases/tag/1.0.0-beta14)
+-------------------
+* Support Android 12
+
 [1.0.0-beta13](https://github.com/hyperwallet/hyperwallet-android-ui-sdk/releases/tag/1.0.0-beta13)
 -------------------
 * Handle HTTP 401

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ allprojects {
 
     }
 
-    project.version = "1.0.0-beta13"
+    project.version = "1.0.0-beta14"
 
 }
 

--- a/transfermethodui/src/main/AndroidManifest.xml
+++ b/transfermethodui/src/main/AndroidManifest.xml
@@ -18,6 +18,7 @@
             android:windowSoftInputMode="adjustResize"/>
 
         <activity
+            android:exported="false"
             android:name="com.hyperwallet.android.ui.transfermethod.view.SelectTransferMethodActivity"
             android:label="@string/mobileAddTransferMethodHeader"
             android:theme="@style/AppTheme.NoActionBar">


### PR DESCRIPTION
Playstore requires the code be compatible with Android 12 

```
Error: If an activity, service, or broadcast receiver uses intent filters and doesn't have an explicitly-declared value for android:exported, your app can't be installed on a device that runs Android 12 or higher.
```

Changes
- Add support to Android 12
